### PR TITLE
Fix remove-btn position

### DIFF
--- a/src/components/CartOverlay/cart-overlay.css
+++ b/src/components/CartOverlay/cart-overlay.css
@@ -96,6 +96,7 @@
     }
     .remove-btn {
       align-self: start;
+      position: absolute;
       top: 4px;
       right: 4px;
       padding: 0;


### PR DESCRIPTION
This should put the **remove button** at the right of the **card** to be consistent in all cards.

**Before:**
![image](https://github.com/user-attachments/assets/0d66ad45-e7d0-4ee8-89a8-c252b9e6bb9d)

**After:**
![image](https://github.com/user-attachments/assets/6d767cc1-0abc-45f1-ac98-6da1dfe06ec4)
